### PR TITLE
fix Calculator test on Android 5

### DIFF
--- a/01-uiautomator/final/UIAutomatorApp/app/src/androidTest/java/net/moudra/uiautomatorapp/AutomatorTest.java
+++ b/01-uiautomator/final/UIAutomatorApp/app/src/androidTest/java/net/moudra/uiautomatorapp/AutomatorTest.java
@@ -41,16 +41,7 @@ public class AutomatorTest {
 
         appButton.clickAndWaitForNewWindow();
 
-        // Scrollable view with apps
-        UiScrollable appViews = new UiScrollable(new UiSelector().scrollable(true));
-        assertTrue(appViews.exists());
-
-        appViews.setAsHorizontalList();
-
-        // Find calculator application
-        UiObject calculatorApp = appViews.getChildByText(new UiSelector()
-                .className("android.widget.TextView"), "Calculator");
-        assertTrue(calculatorApp.exists());
+        UiObject calculatorApp = uiDevice.findObject(new UiSelector().textContains("Calculator"));
 
         calculatorApp.clickAndWaitForNewWindow();
 


### PR DESCRIPTION
It fails because we tested android Launcher implementation but not Calculator.
UiScrollable is not available on Android 5
